### PR TITLE
Migrate to latest dependencies (0.11.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +990,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,12 +1250,12 @@ dependencies = [
 name = "masm-project-template"
 version = "0.1.0"
 dependencies = [
- "miden-assembly 0.16.2",
- "miden-client",
+ "miden-assembly 0.17.0",
+ "miden-client 0.11.6",
  "miden-client-tools",
- "miden-crypto 0.15.7",
- "miden-lib",
- "miden-objects",
+ "miden-crypto 0.15.9",
+ "miden-lib 0.11.4",
+ "miden-objects 0.11.4",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "serde",
@@ -1239,8 +1286,20 @@ checksum = "af5e74b13a68f17c5a52d10adbce489faba95d2bd43d4d48014e4af818f109f8"
 dependencies = [
  "miden-core 0.15.0",
  "thiserror 2.0.12",
- "winter-air",
- "winter-prover",
+ "winter-air 0.12.3",
+ "winter-prover 0.12.3",
+]
+
+[[package]]
+name = "miden-air"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2871bc4f392053cd115d4532e4b0fb164791829cc94b35641ed72480547dfd1"
+dependencies = [
+ "miden-core 0.17.2",
+ "thiserror 2.0.12",
+ "winter-air 0.13.1",
+ "winter-prover 0.13.1",
 ]
 
 [[package]]
@@ -1263,13 +1322,13 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5453d77fc1a7e4642e1fd8855e1d5904087ac1ec53b02549a11af4697df2713"
+checksum = "f27e40b30070599f5e7094ada753b2e9f52b3043f0975ece3f98d839584b1c36"
 dependencies = [
  "log",
  "miden-assembly-syntax",
- "miden-core 0.16.3",
+ "miden-core 0.17.2",
  "miden-mast-package",
  "smallvec",
  "thiserror 2.0.12",
@@ -1277,17 +1336,18 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.16.3"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2319962222c27ea6d8eba4e0ed59c847f816bfc51c9539b4e2a12bfd901c524"
+checksum = "6ab186ac7061b47415b923cf2da88df505f25c333f7caace80fb7760cf9c0590"
 dependencies = [
  "aho-corasick",
  "lalrpop 0.22.2",
  "lalrpop-util 0.22.2",
  "log",
- "miden-core 0.16.3",
+ "miden-core 0.17.2",
  "miden-debug-types",
  "miden-utils-diagnostics",
+ "midenc-hir-type",
  "regex",
  "rustc_version 0.4.1",
  "semver 1.0.26",
@@ -1301,8 +1361,19 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d167d98320b8c05c49a45fe48e60704d3347691d05c922a448841007f6645775"
 dependencies = [
- "miden-lib",
- "miden-objects",
+ "miden-lib 0.10.0",
+ "miden-objects 0.10.0",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "miden-block-prover"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7dbd611fe4a0cf3f5feb68501f74cb70fe62b25cb9ad7242866089470312b8c"
+dependencies = [
+ "miden-lib 0.11.4",
+ "miden-objects 0.11.4",
  "thiserror 2.0.12",
 ]
 
@@ -1317,12 +1388,12 @@ dependencies = [
  "deadpool",
  "deadpool-sync",
  "hex",
- "miden-lib",
- "miden-node-proto-build",
- "miden-objects",
- "miden-remote-prover-client",
- "miden-testing",
- "miden-tx",
+ "miden-lib 0.10.0",
+ "miden-node-proto-build 0.10.1",
+ "miden-objects 0.10.0",
+ "miden-remote-prover-client 0.10.1",
+ "miden-testing 0.10.0",
+ "miden-tx 0.10.0",
  "miette",
  "prost",
  "prost-build",
@@ -1340,17 +1411,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-client"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e408853351a9a1c631d2fac3be4e5e749dd77466d19455086d0a3048f3fb7fb"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "deadpool",
+ "deadpool-sync",
+ "hex",
+ "miden-lib 0.11.4",
+ "miden-node-proto-build 0.11.2",
+ "miden-objects 0.11.4",
+ "miden-remote-prover-client 0.11.2",
+ "miden-testing 0.11.4",
+ "miden-tx 0.11.4",
+ "miette",
+ "prost",
+ "prost-build",
+ "protox 0.7.2",
+ "rand 0.9.1",
+ "rusqlite",
+ "rusqlite_migration",
+ "thiserror 2.0.12",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "uuid",
+ "web-sys",
+]
+
+[[package]]
 name = "miden-client-tools"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa53dadb108dc17c4e7bfd9987c973d98d89cc49228c250235bbf81c9c04d3e6"
 dependencies = [
  "miden-assembly 0.15.0",
- "miden-client",
- "miden-crypto 0.15.7",
- "miden-lib",
- "miden-objects",
- "miden-tx",
+ "miden-client 0.10.0",
+ "miden-crypto 0.15.9",
+ "miden-lib 0.10.0",
+ "miden-objects 0.10.0",
+ "miden-tx 0.10.0",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "serde",
@@ -1380,11 +1484,11 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.16.3"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d432f414f3029470619f41f741c67551d14e282dd0ad19cd276b14eeefdd34b6"
+checksum = "395ad0b07592486e02de3ff7f3bff1d7fa81b1a7120f7f0b1027d650d810bbab"
 dependencies = [
- "miden-crypto 0.15.7",
+ "miden-crypto 0.15.9",
  "miden-debug-types",
  "miden-formatting",
  "num-derive",
@@ -1416,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.15.7"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8d6fde5681ffcae64b32153280476b992578b35842ba62c751fd17b1e5c3c6"
+checksum = "e4329275a11c7d8328b14a7129b21d40183056dcd0d871c3069be6e550d6ca40"
 dependencies = [
  "blake3",
  "cc",
@@ -1440,12 +1544,12 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.16.3"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703e80e02f1f14fdcf154cb947bfaff999da58db13b7e450dcf24808794910f8"
+checksum = "c84e5b15ea6fe0f80688fde2d6e4f5a3b66417d2541388b7a6cf967c6a8a2bc0"
 dependencies = [
  "memchr",
- "miden-crypto 0.15.7",
+ "miden-crypto 0.15.9",
  "miden-formatting",
  "miden-miette",
  "miden-utils-sync",
@@ -1471,8 +1575,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4596588ec57bb419020d6877366f16fd349ab957ff3cc60f2c6ebe33a75b393"
 dependencies = [
  "miden-assembly 0.15.0",
- "miden-objects",
- "miden-stdlib",
+ "miden-objects 0.10.0",
+ "miden-stdlib 0.15.0",
+ "regex",
+ "thiserror 2.0.12",
+ "walkdir",
+]
+
+[[package]]
+name = "miden-lib"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53003668b0c40d9694835046f7b995a7673bcd62c7f7eb442ce9a4cecadf38d9"
+dependencies = [
+ "miden-assembly 0.17.0",
+ "miden-objects 0.11.4",
+ "miden-processor 0.17.2",
+ "miden-stdlib 0.17.2",
+ "rand 0.9.1",
  "regex",
  "thiserror 2.0.12",
  "walkdir",
@@ -1480,13 +1600,13 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.16.3"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04924185b8561234b891c87920c50c14f15bbcee32334855d0bc7dd0141bd75c"
+checksum = "1e9d87c128f467874b272fec318e792385e35b14d200408a10d30909228db864"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
- "miden-core 0.16.3",
+ "miden-core 0.17.2",
 ]
 
 [[package]]
@@ -1544,6 +1664,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-node-proto-build"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674a01e850ad65e8cdd7fa864b728dddc17e3d90944b1ff96933211bb1c806b"
+dependencies = [
+ "anyhow",
+ "prost",
+ "protox 0.8.0",
+ "tonic-build",
+]
+
+[[package]]
 name = "miden-objects"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,8 +1686,8 @@ dependencies = [
  "miden-assembly 0.15.0",
  "miden-core 0.15.0",
  "miden-crypto 0.14.1",
- "miden-processor",
- "miden-verifier",
+ "miden-processor 0.15.0",
+ "miden-verifier 0.15.0",
  "rand 0.9.1",
  "rand_xoshiro",
  "semver 1.0.26",
@@ -1566,17 +1698,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-objects"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bdb0ef7d8a30213d991bbe44ef3f64dbb9caeebb89cfd996565a9a7a18dab5"
+dependencies = [
+ "bech32",
+ "getrandom 0.3.3",
+ "miden-assembly 0.17.0",
+ "miden-core 0.17.2",
+ "miden-crypto 0.15.9",
+ "miden-processor 0.17.2",
+ "miden-utils-sync",
+ "miden-verifier 0.17.2",
+ "rand 0.9.1",
+ "rand_xoshiro",
+ "semver 1.0.26",
+ "serde",
+ "thiserror 2.0.12",
+ "toml 0.8.23",
+ "winter-rand-utils 0.13.1",
+]
+
+[[package]]
 name = "miden-processor"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "024c8118fbbd61dd58d764e9a714cad6c89d8b9b58bfaecfa0a30657f92b0fc9"
 dependencies = [
- "miden-air",
+ "miden-air 0.15.0",
  "miden-core 0.15.0",
  "miden-miette",
  "thiserror 2.0.12",
  "tracing",
- "winter-prover",
+ "winter-prover 0.12.3",
+]
+
+[[package]]
+name = "miden-processor"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64304339292cc4e50a7b534197326824eeb21f3ffaadd955be63cc57093854ed"
+dependencies = [
+ "miden-air 0.17.2",
+ "miden-core 0.17.2",
+ "miden-debug-types",
+ "miden-utils-diagnostics",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "winter-prover 0.13.1",
 ]
 
 [[package]]
@@ -1585,11 +1756,25 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78191a0107c16d78b6d687cb55f30ef7d465d40f1f83e0e7d4627bc320ec36e0"
 dependencies = [
- "miden-air",
- "miden-processor",
+ "miden-air 0.15.0",
+ "miden-processor 0.15.0",
  "tracing",
- "winter-maybe-async",
- "winter-prover",
+ "winter-maybe-async 0.12.0",
+ "winter-prover 0.12.3",
+]
+
+[[package]]
+name = "miden-prover"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21637f9dcca045f7bf65da20d42f37f86373b43092ae9df9a230cffb86f4d6d"
+dependencies = [
+ "miden-air 0.17.2",
+ "miden-debug-types",
+ "miden-processor 0.17.2",
+ "tracing",
+ "winter-maybe-async 0.13.1",
+ "winter-prover 0.13.1",
 ]
 
 [[package]]
@@ -1600,9 +1785,30 @@ checksum = "4dca5a5de81b50844795f38a90297ac5068f79ea551980d0926ab150b42e78c2"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
- "miden-node-proto-build",
- "miden-objects",
- "miden-tx",
+ "miden-node-proto-build 0.10.1",
+ "miden-objects 0.10.0",
+ "miden-tx 0.10.0",
+ "miette",
+ "prost",
+ "prost-build",
+ "protox 0.8.0",
+ "thiserror 2.0.12",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tonic-web-wasm-client",
+]
+
+[[package]]
+name = "miden-remote-prover-client"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a421a9b5e8f09bda3d91a2d17f7d6804107bd5bb775a61a82b4fe47204d1f3ae"
+dependencies = [
+ "getrandom 0.3.3",
+ "miden-node-proto-build 0.11.2",
+ "miden-objects 0.11.4",
+ "miden-tx 0.11.4",
  "miette",
  "prost",
  "prost-build",
@@ -1625,6 +1831,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-stdlib"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7308c32ec08dd75c29653315a0f395786d391c2fe55a5318ec39662a31de6a26"
+dependencies = [
+ "env_logger",
+ "miden-assembly 0.17.0",
+ "miden-core 0.17.2",
+ "miden-processor 0.17.2",
+ "miden-utils-sync",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "miden-testing"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,16 +1852,36 @@ checksum = "20801e4918082b41b78d85d6261d836caa7f5dbe3552a82b14073c100e648366"
 dependencies = [
  "anyhow",
  "async-trait",
- "miden-block-prover",
- "miden-lib",
- "miden-objects",
- "miden-processor",
- "miden-tx",
+ "miden-block-prover 0.10.0",
+ "miden-lib 0.10.0",
+ "miden-objects 0.10.0",
+ "miden-processor 0.15.0",
+ "miden-tx 0.10.0",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "thiserror 2.0.12",
- "winter-maybe-async",
- "winterfell",
+ "winter-maybe-async 0.12.0",
+ "winterfell 0.12.0",
+]
+
+[[package]]
+name = "miden-testing"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529911c03fccb971466d96673bb3a6300c9786d24f76262fed13b076a4aad4a0"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "miden-block-prover 0.11.4",
+ "miden-lib 0.11.4",
+ "miden-objects 0.11.4",
+ "miden-processor 0.17.2",
+ "miden-tx 0.11.4",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "thiserror 2.0.12",
+ "tokio",
+ "winterfell 0.13.1",
 ]
 
 [[package]]
@@ -1651,23 +1891,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca703cc8580c01df23beb50fbb7b62f9b8157c2dc4b8a0b3ba6a9a6d77ffaf99"
 dependencies = [
  "async-trait",
- "miden-lib",
- "miden-objects",
- "miden-processor",
- "miden-prover",
- "miden-verifier",
+ "miden-lib 0.10.0",
+ "miden-objects 0.10.0",
+ "miden-processor 0.15.0",
+ "miden-prover 0.15.0",
+ "miden-verifier 0.15.0",
  "rand 0.9.1",
  "thiserror 2.0.12",
- "winter-maybe-async",
+ "winter-maybe-async 0.12.0",
+]
+
+[[package]]
+name = "miden-tx"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d21a678142e02cd5a242b9de58de429694df397df117333e0c3416af87c749"
+dependencies = [
+ "miden-lib 0.11.4",
+ "miden-objects 0.11.4",
+ "miden-processor 0.17.2",
+ "miden-prover 0.17.2",
+ "miden-verifier 0.17.2",
+ "rand 0.9.1",
+ "thiserror 2.0.12",
+ "tokio",
 ]
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.16.3"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf0aa85171045c0c081ee2b2a05665f4cc06157a1ad899734d8389006a659a8"
+checksum = "e9bf9a2c1cf3e3694d0eb347695a291602a57f817dd001ac838f300799576a69"
 dependencies = [
- "miden-crypto 0.15.7",
+ "miden-crypto 0.15.9",
  "miden-debug-types",
  "miden-miette",
  "paste",
@@ -1676,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.16.3"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5fb22ce7af59baae7dafe3c68ddaacb738108d3bb5ecb6738088daa87be825"
+checksum = "bb026e69ae937b2a83bf69ea86577e0ec2450cb22cce163190b9fd42f2972b63"
 dependencies = [
  "lock_api",
  "loom",
@@ -1691,11 +1947,35 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0043e6fe42c3f349d333e85793d07e3984a05d28a73620b3ff76940cfa74f8"
 dependencies = [
- "miden-air",
+ "miden-air 0.15.0",
  "miden-core 0.15.0",
  "thiserror 2.0.12",
  "tracing",
- "winter-verifier",
+ "winter-verifier 0.12.3",
+]
+
+[[package]]
+name = "miden-verifier"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a305e5e2c68d10bcb8e2ed3dc38e54bc3a538acc9eadc154b713d5bb47af22"
+dependencies = [
+ "miden-air 0.17.2",
+ "miden-core 0.17.2",
+ "thiserror 2.0.12",
+ "tracing",
+ "winter-verifier 0.13.1",
+]
+
+[[package]]
+name = "midenc-hir-type"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e381ba23e4f57ffa0d6039113f6d6004e5b8c7ae6cb909329b48f2ab525e8680"
+dependencies = [
+ "miden-formatting",
+ "smallvec",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2005,6 +2285,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -3806,9 +4101,22 @@ checksum = "48a9ee4b14f192be4b0f253d6cc6241844664d6d6684819b6d9b074f4b85af14"
 dependencies = [
  "libm",
  "winter-crypto 0.12.0",
- "winter-fri",
+ "winter-fri 0.12.2",
  "winter-math 0.12.0",
  "winter-utils 0.12.0",
+]
+
+[[package]]
+name = "winter-air"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef01227f23c7c331710f43b877a8333f5f8d539631eea763600f1a74bf018c7c"
+dependencies = [
+ "libm",
+ "winter-crypto 0.13.1",
+ "winter-fri 0.13.1",
+ "winter-math 0.13.1",
+ "winter-utils 0.13.1",
 ]
 
 [[package]]
@@ -3847,6 +4155,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "winter-fri"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd592b943f9d65545683868aaf1b601eb66e52bfd67175347362efff09101d3a"
+dependencies = [
+ "winter-crypto 0.13.1",
+ "winter-math 0.13.1",
+ "winter-utils 0.13.1",
+]
+
+[[package]]
 name = "winter-math"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3875,18 +4194,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "winter-maybe-async"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "winter-prover"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e1ad2747c0f67f3aab25c2753cb7ee321e06722dd1f011344faeee7e2828a4"
 dependencies = [
  "tracing",
- "winter-air",
+ "winter-air 0.12.3",
  "winter-crypto 0.12.0",
- "winter-fri",
+ "winter-fri 0.12.2",
  "winter-math 0.12.0",
- "winter-maybe-async",
+ "winter-maybe-async 0.12.0",
  "winter-utils 0.12.0",
+]
+
+[[package]]
+name = "winter-prover"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cc631ed56cd39b78ef932c1ec4060cc6a44d114474291216c32f56655b3048"
+dependencies = [
+ "tracing",
+ "winter-air 0.13.1",
+ "winter-crypto 0.13.1",
+ "winter-fri 0.13.1",
+ "winter-math 0.13.1",
+ "winter-maybe-async 0.13.1",
+ "winter-utils 0.13.1",
 ]
 
 [[package]]
@@ -3923,6 +4267,9 @@ name = "winter-utils"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "winter-verifier"
@@ -3930,11 +4277,24 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a980cd314dddc2f4c9cdbc77127e6390238bb8b7541b6f627541ca35223f8ff"
 dependencies = [
- "winter-air",
+ "winter-air 0.12.3",
  "winter-crypto 0.12.0",
- "winter-fri",
+ "winter-fri 0.12.2",
  "winter-math 0.12.0",
  "winter-utils 0.12.0",
+]
+
+[[package]]
+name = "winter-verifier"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0425ea81f8f703a1021810216da12003175c7974a584660856224df04b2e2fdb"
+dependencies = [
+ "winter-air 0.13.1",
+ "winter-crypto 0.13.1",
+ "winter-fri 0.13.1",
+ "winter-math 0.13.1",
+ "winter-utils 0.13.1",
 ]
 
 [[package]]
@@ -3943,9 +4303,20 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0568d7d853c01210440d4cdacae6586678931fcb45a1bc26af6b4091aea864"
 dependencies = [
- "winter-air",
- "winter-prover",
- "winter-verifier",
+ "winter-air 0.12.3",
+ "winter-prover 0.12.3",
+ "winter-verifier 0.12.3",
+]
+
+[[package]]
+name = "winterfell"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f824ddd5aec8ca6a54307f20c115485a8a919ea94dd26d496d856ca6185f4f"
+dependencies = [
+ "winter-air 0.13.1",
+ "winter-prover 0.13.1",
+ "winter-verifier 0.13.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,10 +191,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bech32"
@@ -292,6 +314,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +349,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -350,6 +407,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -414,12 +477,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -453,6 +529,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,7 +565,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -510,10 +598,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "ena"
@@ -582,6 +704,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +724,18 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -703,6 +847,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -712,8 +857,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -741,6 +888,17 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -800,6 +958,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -943,6 +1119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1216,20 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -1250,12 +1449,13 @@ dependencies = [
 name = "masm-project-template"
 version = "0.1.0"
 dependencies = [
- "miden-assembly 0.17.0",
+ "miden-assembly 0.17.2",
  "miden-client 0.11.6",
  "miden-client-tools",
- "miden-crypto 0.15.9",
+ "miden-crypto 0.17.0",
  "miden-lib 0.11.4",
  "miden-objects 0.11.4",
+ "miden-tx 0.11.4",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "serde",
@@ -1322,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27e40b30070599f5e7094ada753b2e9f52b3043f0975ece3f98d839584b1c36"
+checksum = "345ae47710bbb4c6956dcc669a537c5cf2081879b6238c0df6da50e84a77ea3f"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1543,6 +1743,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-crypto"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8c283ed3017d58d9b648d9b1099f26abff52b185ecbb7b91ff4fb406c286b7"
+dependencies = [
+ "blake3",
+ "cc",
+ "chacha20poly1305",
+ "clap",
+ "flume",
+ "getrandom 0.2.16",
+ "glob",
+ "hashbrown",
+ "hkdf",
+ "k256",
+ "num",
+ "num-complex",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "rand_hc",
+ "rayon",
+ "sha3",
+ "thiserror 2.0.12",
+ "winter-crypto 0.13.1",
+ "winter-math 0.13.1",
+ "winter-rand-utils 0.13.1",
+ "winter-utils 0.13.1",
+ "zeroize",
+]
+
+[[package]]
 name = "miden-debug-types"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,7 +1820,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53003668b0c40d9694835046f7b995a7673bcd62c7f7eb442ce9a4cecadf38d9"
 dependencies = [
- "miden-assembly 0.17.0",
+ "miden-assembly 0.17.2",
  "miden-objects 0.11.4",
  "miden-processor 0.17.2",
  "miden-stdlib 0.17.2",
@@ -1705,7 +1937,7 @@ checksum = "68bdb0ef7d8a30213d991bbe44ef3f64dbb9caeebb89cfd996565a9a7a18dab5"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
- "miden-assembly 0.17.0",
+ "miden-assembly 0.17.2",
  "miden-core 0.17.2",
  "miden-crypto 0.15.9",
  "miden-processor 0.17.2",
@@ -1837,7 +2069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7308c32ec08dd75c29653315a0f395786d391c2fe55a5318ec39662a31de6a26"
 dependencies = [
  "env_logger",
- "miden-assembly 0.17.0",
+ "miden-assembly 0.17.2",
  "miden-core 0.17.2",
  "miden-processor 0.17.2",
  "miden-utils-sync",
@@ -2035,6 +2267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,6 +2408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,10 +2528,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2541,6 +2809,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,6 +2909,16 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
 
 [[package]]
 name = "ring"
@@ -2811,6 +3098,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,6 +3209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,6 +3243,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "siphasher"
@@ -2971,6 +3293,19 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "string_cache"
@@ -3541,6 +3876,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,12 @@ edition = "2024"
 default-run = "masm-project-template"
 
 [dependencies]
-miden-client = { version = "=0.11", features = ["testing", "tonic", "sqlite"] }
-miden-lib = { version = "=0.11", default-features = false }
-miden-objects = { version = "=0.11", default-features = false }
-miden-crypto = { version = "0.15.9" }
-miden-assembly = "=0.17.0"
+miden-client = { version = "0.11.6", features = ["testing", "tonic", "sqlite"] }
+miden-lib = { version = "0.11.4", default-features = false }
+miden-objects = { version = "0.11.4", default-features = false }
+miden-crypto = { version = "0.17.0", features = ["executable"] }
+miden-tx = "0.11.4"
+miden-assembly = "0.17.2"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2024"
 default-run = "masm-project-template"
 
 [dependencies]
-miden-client = { version = "=0.10", features = ["testing", "tonic", "sqlite"] }
-miden-lib = { version = "=0.10.0", default-features = false }
-miden-objects = { version = "=0.10.0", default-features = false }
-miden-crypto = { version = "0.15.6" }
-miden-assembly = "=0.16.2"
+miden-client = { version = "=0.11", features = ["testing", "tonic", "sqlite"] }
+miden-lib = { version = "=0.11", default-features = false }
+miden-objects = { version = "=0.11", default-features = false }
+miden-crypto = { version = "0.15.9" }
+miden-assembly = "=0.17.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/src/bin/increment.rs
+++ b/src/bin/increment.rs
@@ -1,33 +1,35 @@
 // src/main.rs  — cargo run
 use std::{fs, path::Path};
 
-use miden_client_tools::{
+use masm_project_template::common::{
     create_library, create_tx_script, delete_keystore_and_store, instantiate_client,
 };
-
-use miden_client::{
-    Word, account::AccountId, rpc::Endpoint, transaction::TransactionRequestBuilder,
-};
+use miden_client::{Word, account::Address, rpc::Endpoint, transaction::TransactionRequestBuilder};
 use tokio::time::{Duration, sleep};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    delete_keystore_and_store(None).await;
+    delete_keystore_and_store().await;
 
     // -------------------------------------------------------------------------
     // Instantiate client
     // -------------------------------------------------------------------------
     let endpoint = Endpoint::testnet();
-    let mut client = instantiate_client(endpoint, None).await.unwrap();
+    let mut client = instantiate_client(endpoint).await.unwrap();
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("⛓  Latest block: {}", sync_summary.block_num);
 
     // -------------------------------------------------------------------------
     // STEP 1 – Query Counter State
-    // -------------------------------------------------------------------------
     let (_network_id, counter_contract_id) =
-        AccountId::from_bech32("mtst1qr845cd3fadh5qrc96rvwqepsg8fjyts").unwrap();
+        Address::from_bech32("mtst1qpcls0rfcszxvqrhnvn3xvqvapcqqg88tg9").unwrap();
+
+    // Extract account ID from the address
+    let counter_contract_id = match counter_contract_id {
+        Address::AccountId(account_id_address) => account_id_address.id(),
+        _ => panic!("Invalid address"),
+    };
 
     client
         .import_account_by_id(counter_contract_id)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,29 @@
 use std::{fs, path::Path};
 
-use masm_project_template::common::create_public_immutable_contract;
-
-use miden_client_tools::{
-    create_library, create_tx_script, delete_keystore_and_store, instantiate_client,
+use masm_project_template::common::{
+    create_library, create_public_immutable_contract, create_tx_script, delete_keystore_and_store,
+    instantiate_client,
 };
 
 use miden_client::{
-    Word, keystore::FilesystemKeyStore, rpc::Endpoint, transaction::TransactionRequestBuilder,
+    Word,
+    account::{AccountIdAddress, Address, AddressInterface},
+    keystore::FilesystemKeyStore,
+    rpc::Endpoint,
+    transaction::TransactionRequestBuilder,
 };
 use miden_objects::account::NetworkId;
 use tokio::time::{Duration, sleep};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    delete_keystore_and_store(None).await;
+    delete_keystore_and_store().await;
 
     // -------------------------------------------------------------------------
     // Instantiate client
     // -------------------------------------------------------------------------
     let endpoint = Endpoint::testnet();
-    let mut client = instantiate_client(endpoint, None).await.unwrap();
+    let mut client = instantiate_client(endpoint).await.unwrap();
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("⛓  Latest block: {}", sync_summary.block_num);
@@ -37,10 +40,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_account(&counter_contract, Some(counter_seed), false)
         .await
         .unwrap();
+    let addr = AccountIdAddress::new(counter_contract.id(), AddressInterface::Unspecified);
 
+    // build address of faucet
+    let address = Address::AccountId(addr);
     println!(
         "📄 Counter contract ID: {}",
-        counter_contract.id().to_bech32(NetworkId::Testnet)
+        address.to_bech32(NetworkId::Testnet)
     );
 
     // -------------------------------------------------------------------------
@@ -79,10 +85,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
 
     // Deleting keystore & store to show how to fetch public state
-    delete_keystore_and_store(None).await;
+    delete_keystore_and_store().await;
 
     let endpoint = Endpoint::testnet();
-    let mut client = instantiate_client(endpoint, None).await?;
+    let mut client = instantiate_client(endpoint).await?;
 
     client
         .import_account_by_id(counter_contract.id())

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use masm_project_template::common::{
 use miden_client::{
     Word,
     account::{AccountIdAddress, Address, AddressInterface},
-    keystore::FilesystemKeyStore,
     rpc::Endpoint,
     transaction::TransactionRequestBuilder,
 };


### PR DESCRIPTION
- Update dependencies
- Remove `miden_client_tool` and use the utility functions under `common` to avoid maintaining both side