### PR TITLE
perf: reuse loaded counter.masm code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,10 +54,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let script_code =
         fs::read_to_string(Path::new("./masm/scripts/increment_script.masm")).unwrap();
 
-    let account_code = fs::read_to_string(Path::new("./masm/accounts/counter.masm")).unwrap();
     let library_path = "external_contract::counter_contract";
 
-    let library = create_library(account_code, library_path).unwrap();
+    let library = create_library(counter_code.clone(), library_path).unwrap();
 
     let tx_script = create_tx_script(script_code, Some(library)).unwrap();
 

--- a/tests/increment_count_test.rs
+++ b/tests/increment_count_test.rs
@@ -46,10 +46,9 @@ async fn increment_counter_with_script() -> Result<(), ClientError> {
     let script_code =
         fs::read_to_string(Path::new("./masm/scripts/increment_script.masm")).unwrap();
 
-    let account_code = fs::read_to_string(Path::new("./masm/accounts/counter.masm")).unwrap();
     let library_path = "external_contract::counter_contract";
 
-    let library = create_library(account_code, library_path).unwrap();
+    let library = create_library(counter_code.clone(), library_path).unwrap();
 
     let tx_script = create_tx_script(script_code, Some(library)).unwrap();
 


### PR DESCRIPTION
Reuse the already loaded counter.masm source when building the external contract library instead of reading the file twice. This removes redundant disk I/O and string allocations in both the main example and the increment_counter_with_script test