### PR TITLE
perf: remove redundant clones in tx flow

### DIFF
--- a/src/bin/increment.rs
+++ b/src/bin/increment.rs
@@ -70,8 +70,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .new_transaction(counter_contract_id, tx_increment_request)
         .await
         .unwrap();
-
-    let _ = client.submit_transaction(tx_result.clone()).await;
+    let tx_id = tx_result.executed_transaction().id();
+    let _ = client.submit_transaction(tx_result).await;
 
     println!("🚀 Increment transaction submitted – waiting for finality …");
     sleep(Duration::from_secs(7)).await;
@@ -92,7 +92,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("✅ Success! The counter was incremented.");
 
-    let tx_id = tx_result.executed_transaction().id();
     println!(
         "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
         tx_id

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let library_path = "external_contract::counter_contract";
 
-    let library = create_library(counter_code.clone(), library_path).unwrap();
+    let library = create_library(counter_code, library_path).unwrap();
 
     let tx_script = create_tx_script(script_code, Some(library)).unwrap();
 
@@ -72,8 +72,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .new_transaction(counter_contract.id(), tx_increment_request)
         .await
         .unwrap();
-
-    let _ = client.submit_transaction(tx_result.clone()).await;
+    let tx_id = tx_result.executed_transaction().id();
+    let _ = client.submit_transaction(tx_result).await;
 
     println!("🚀 Increment transaction submitted – waiting for finality …");
     sleep(Duration::from_secs(7)).await;
@@ -103,7 +103,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("🔢 Counter value after tx: {}", counter_val);
     println!("✅ Success! The counter was incremented.");
 
-    let tx_id = tx_result.executed_transaction().id();
     println!(
         "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
         tx_id

--- a/tests/increment_count_test.rs
+++ b/tests/increment_count_test.rs
@@ -48,7 +48,7 @@ async fn increment_counter_with_script() -> Result<(), ClientError> {
 
     let library_path = "external_contract::counter_contract";
 
-    let library = create_library(counter_code.clone(), library_path).unwrap();
+    let library = create_library(counter_code, library_path).unwrap();
 
     let tx_script = create_tx_script(script_code, Some(library)).unwrap();
 


### PR DESCRIPTION
Before this change we were cloning tx_result before submitting transactions and cloning counter_code when building the library, even though the original values were not reused afterward. This caused unnecessary allocations and copies without any functional benefit.
Removed redundant clones by reusing the original tx_result and String values: tx_id is derived before submit_transaction is called, and the contract source String is passed by value into create_library where appropriate.